### PR TITLE
Fortran wrapper without static.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ extract_data.py
 !scripts/compile_opt.sh
 !scripts/compile_debug.sh
 !scripts/extract_data.py
+compile_commands.json

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,10 +15,10 @@ else ()
 endif ()
 
 # Include Directories (for all targets)
-include_directories(include)
+include_directories(include ${CMAKE_BINARY_DIR})
 
 # wildcard all the sources in src
-file(GLOB SOURCESLIB src/*.cpp)
+file(GLOB SOURCESLIB src/*.cpp src/*.f95)
 
 # Library
 add_library(micropp ${SOURCESLIB})

--- a/include/ell.hpp
+++ b/include/ell.hpp
@@ -61,8 +61,9 @@ int ell_print_full(ell_matrix *m);
 
 void ell_free(ell_matrix *m);
 
-int ell_solve_cgpd_struct(ell_solver *solver, ell_matrix *m, int nFields,
-                          int dim, int nn, double *b, double *x);
+int ell_solve_cgpd_struct(ell_solver *solver, const ell_matrix * const m,
+                          int nFields, int dim, int nn,
+                          const double * const b, double *x);
 
 void ell_add_struct2D(ell_matrix *m, int ex, int ey, double *Ae,
                       int nFields, int nx, int ny);

--- a/include/micro.hpp
+++ b/include/micro.hpp
@@ -183,11 +183,13 @@ class micropp {
 		~micropp();
 
 		// common Functions
-		int get_nl_flag(int gp_id) const;
+		int get_nl_flag(const int gp_id) const;
 		void set_macro_strain(const int gp_id, const double *macro_strain);
-		void get_macro_stress(const int gp_id, double *macro_stress);
-		void get_macro_ctan(const int gp_id, double *macro_ctan);
+		void get_macro_stress(const int gp_id, double *macro_stress) const;
+		void get_macro_ctan(const int gp_id, double *macro_ctan) const;
 		void homogenize();
 		void output(int tstep, int gp_id);
-		void write_info_files();		void update_vars();
+		void write_info_files();
+		void update_vars();
+		void print_info() const;
 };

--- a/include/micro.hpp
+++ b/include/micro.hpp
@@ -129,7 +129,7 @@ class micropp {
 		void get_elem_rhs(bool *nl_flag, Rest...) const;
 
 		template <typename... Rest>
-		void get_elem_mat(Rest...);
+		void get_elem_mat(Rest...) const;
 
 		void set_displ(double *eps);
 		double assembly_rhs(bool *nl_flag);
@@ -150,8 +150,8 @@ class micropp {
 		template <typename... Rest>
 		void getElemDisp(double *elem_disp, Rest...) const;
 
-		void calc_ave_stress(double stress_ave[6]);
-		void calc_ave_strain(double strain_ave[6]);
+		void calc_ave_stress(double stress_ave[6]) const;
+		void calc_ave_strain(double strain_ave[6]) const;
 
 		void calc_fields();
 
@@ -161,11 +161,11 @@ class micropp {
 		//double get_inv_2(const double *tensor);
 
 		void get_ctan_plast_sec(int ex, int ey, int ez, int gp,
-		                        double ctan[6][6]);
+		                        double ctan[6][6]) const;
 		void get_ctan_plast_exact(int ex, int ey, int ez, int gp,
-		                          double ctan[6][6]);
+		                          double ctan[6][6]) const;
 		void get_ctan_plast_pert(int ex, int ey, int ez, int gp,
-		                         double ctan[6][6]);
+		                         double ctan[6][6]) const;
 
 		void get_dev_tensor(double tensor[6], double tensor_dev[6]) const;
 		void plastic_step(const material_t *material, double eps[6],

--- a/src/ell.cpp
+++ b/src/ell.cpp
@@ -116,9 +116,11 @@ int ell_solve_jacobi_2D(ell_solver *solver, ell_matrix *m, int nFields,
 	return 0;
 }
 
-int ell_solve_cgpd_struct(ell_solver *solver, ell_matrix *m, int nFields,
-                          int dim, int nn, double *b, double *x)
+int ell_solve_cgpd_struct(ell_solver *solver, const ell_matrix * const m,
+                          int nFields, int dim, int nn,
+                          const double * const b, double *x)
 {
+	INST_START;
 	/* Conjugate Gradient Algorithm (CG) with Jacobi Preconditioner
 	 * r_1 residue in actual iteration
 	 * z_1 = K^-1 * r_0 actual auxiliar vector
@@ -138,7 +140,10 @@ int ell_solve_cgpd_struct(ell_solver *solver, ell_matrix *m, int nFields,
 	const int shift =  (dim == 2) ? 4 : 13;
 	for (int i = 0; i < nn; i++) {
 		for (int d = 0; d < nFields; d++)
-			solver->k[i * nFields + d] = 1 / m->vals[i * nFields * m->nnz + shift * nFields + d * m->nnz + d];
+			solver->k[i * nFields + d] = 1 / m->vals[i * nFields * m->nnz
+			                                         + shift * nFields
+			                                         + d * m->nnz
+			                                         + d];
 	}
 
 	for (int i = 0; i < nn*dim; i++)

--- a/src/homogenize.cpp
+++ b/src/homogenize.cpp
@@ -68,7 +68,6 @@ void micropp<tdim>::get_macro_ctan(const int gp_id, double *macro_ctan)
 		macro_ctan[i] = gp_list[gp_id].macro_ctan[i];
 }
 
-
 template <int tdim>
 void micropp<tdim>::homogenize()
 {
@@ -79,21 +78,21 @@ void micropp<tdim>::homogenize()
 
 		inv_max = -1.0e10;
 
-		if ((is_linear(gp_ptr->macro_strain) == true) && (!gp_ptr->allocated)) {
+		if (is_linear(gp_ptr->macro_strain) && (!gp_ptr->allocated)) {
 
 			// S = CL : E
 			for (int i = 0; i < nvoi; ++i) {
-				double tmp = 0;
+				gp_ptr->macro_stress[i] = 0.0;
 				for (int j = 0; j < nvoi; ++j)
-					tmp += ctan_lin[i * nvoi + j] * gp_ptr->macro_strain[j];
-				gp_ptr->macro_stress[i] = tmp;
+					gp_ptr->macro_stress[i] += ctan_lin[i * nvoi + j]
+						* gp_ptr->macro_strain[j];
 			}
 			// C = CL
 			for (int i = 0; i < nvoi; ++i)
 				for (int j = 0; j < nvoi; ++j)
 					gp_ptr->macro_ctan[i * nvoi + j] = ctan_lin[i * nvoi + j];
 
-			for (int i = 0; i < (1 + nvoi); ++i) {
+			for (int i = 0; i < (nvoi + 1); ++i) {
 				gp_ptr->nr_its[i] = 0;
 				gp_ptr->nr_err[i] = 0.0;
 			}
@@ -117,7 +116,7 @@ void micropp<tdim>::homogenize()
 			bool nl_flag;
 			double nr_err;
 
-			set_displ(gp_ptr->macro_strain);
+			set_displ(gp_ptr->macro_strain);  // Acts on u
 			newton_raphson(&nl_flag, &nr_its, &nr_err);
 			calc_ave_stress(gp_ptr->macro_stress);
 
@@ -147,7 +146,7 @@ void micropp<tdim>::homogenize()
 					eps_1[v] = gp_ptr->macro_strain[v];
 				eps_1[i] += dEps;
 
-				set_displ(eps_1);
+				set_displ(eps_1);   // Acts on u
 				newton_raphson(&nl_flag, &nr_its, &nr_err);
 				calc_ave_stress(sig_1);
 				for (int v = 0; v < nvoi; ++v)

--- a/src/homogenize.cpp
+++ b/src/homogenize.cpp
@@ -50,7 +50,7 @@ void micropp<tdim>::set_macro_strain(const int gp_id, const double *macro_strain
 
 
 template <int tdim>
-void micropp<tdim>::get_macro_stress(const int gp_id, double *macro_stress)
+void micropp<tdim>::get_macro_stress(const int gp_id, double *macro_stress) const
 {
 	assert(gp_id < ngp);
 	assert(ngp > 0);
@@ -60,7 +60,7 @@ void micropp<tdim>::get_macro_stress(const int gp_id, double *macro_stress)
 
 
 template <int tdim>
-void micropp<tdim>::get_macro_ctan(const int gp_id, double *macro_ctan)
+void micropp<tdim>::get_macro_ctan(const int gp_id, double *macro_ctan) const
 {
 	assert(gp_id < ngp);
 	assert(ngp > 0);

--- a/src/micro2D.cpp
+++ b/src/micro2D.cpp
@@ -314,7 +314,7 @@ double micropp<2>::assembly_rhs(bool *non_linear)
 
 template <>
 template <>
-void micropp<2>::get_elem_mat(double Ae[2 * 4 * 2 * 4 ], int ex, int ey)
+void micropp<2>::get_elem_mat(double Ae[2 * 4 * 2 * 4], int ex, int ey) const
 {
 	INST_START;
 
@@ -382,7 +382,7 @@ void micropp<2>::assembly_mat()
 
 
 template <>
-void micropp<2>::calc_ave_stress(double stress_ave[6])
+void micropp<2>::calc_ave_stress(double stress_ave[6]) const
 {
 	bool non_linear_flag;
 	const double wg = (1 / 4.0) * dx * dy;
@@ -417,7 +417,7 @@ void micropp<2>::calc_ave_stress(double stress_ave[6])
 
 
 template <>
-void micropp<2>::calc_ave_strain(double strain_ave[6])
+void micropp<2>::calc_ave_strain(double strain_ave[6]) const
 {
 	const double wg = (1 / 4.0) * dx * dy;
 
@@ -433,7 +433,7 @@ void micropp<2>::calc_ave_strain(double strain_ave[6])
 				double strain_gp[6];
 
 				get_strain(gp, strain_gp, ex, ey);
-				for (int v = 0; v < nvoi; v++)
+				for (int v = 0; v < nvoi; ++v)
 					strain_aux[v] += strain_gp[v] * wg;
 			}
 

--- a/src/micro3D.cpp
+++ b/src/micro3D.cpp
@@ -87,8 +87,8 @@ template <>
 void micropp<3>::set_displ(double *eps)
 {
 	// z = 0
-	for (int i = 0; i < nx; i++) {
-		for (int j = 0; j < ny; j++) {
+	for (int i = 0; i < nx; ++i) {
+		for (int j = 0; j < ny; ++j) {
 			const int n = nod_index(i, j, 0);
 			const double xcoor = i * dx;
 			const double ycoor = j * dy;
@@ -102,8 +102,8 @@ void micropp<3>::set_displ(double *eps)
 		}
 	}
 	// z = lx
-	for (int i = 0; i < nx; i++) {
-		for (int j = 0; j < ny; j++) {
+	for (int i = 0; i < nx; ++i) {
+		for (int j = 0; j < ny; ++j) {
 			const int n = nod_index(i, j, nz - 1);
 			const double xcoor = i * dx;
 			const double ycoor = j * dy;
@@ -118,8 +118,8 @@ void micropp<3>::set_displ(double *eps)
 	}
 
 	// y = 0
-	for (int i = 0; i < nx; i++) {
-		for (int k = 1; k < nz - 1; k++) {
+	for (int i = 0; i < nx; ++i) {
+		for (int k = 1; k < nz - 1; ++k) {
 			const int n = nod_index(i, 0, k);
 			const double xcoor = i * dx;
 			const double ycoor = 0.0;
@@ -134,8 +134,8 @@ void micropp<3>::set_displ(double *eps)
 	}
 
 	// y = ly
-	for (int i = 0; i < nx; i++) {
-		for (int k = 1; k < nz - 1; k++) {
+	for (int i = 0; i < nx; ++i) {
+		for (int k = 1; k < nz - 1; ++k) {
 			const int n = nod_index(i, ny - 1, k);
 			const double xcoor = i * dx;
 			const double ycoor = ly;
@@ -150,8 +150,8 @@ void micropp<3>::set_displ(double *eps)
 	}
 
 	// x=0
-	for (int j = 1; j < ny - 1; j++) {
-		for (int k = 1; k < nz - 1; k++) {
+	for (int j = 1; j < ny - 1; ++j) {
+		for (int k = 1; k < nz - 1; ++k) {
 			const int n = nod_index(0, j, k);
 			const double xcoor = 0.0;
 			const double ycoor = j * dy;
@@ -166,8 +166,8 @@ void micropp<3>::set_displ(double *eps)
 	}
 
 	// x=lx
-	for (int j = 1; j < ny - 1; j++) {
-		for (int k = 1; k < nz - 1; k++) {
+	for (int j = 1; j < ny - 1; ++j) {
+		for (int k = 1; k < nz - 1; ++k) {
 			const int n = nod_index(nx - 1, j, k);
 			const double xcoor = lx;
 			const double ycoor = j * dy;
@@ -185,18 +185,17 @@ void micropp<3>::set_displ(double *eps)
 
 template <>
 template <>
-void micropp<3>::get_stress(int gp, double eps[6], bool * non_linear,
+void micropp<3>::get_stress(int gp, double eps[6], bool *non_linear,
                             double *stress_gp, int ex, int ey, int ez) const
 {
 	*non_linear = false;
 
-	double ctan[6][6];
 	const int e = glo_elem3D(ex, ey, ez);
 	const material_t material = get_material(e);
 	const double mu = material.mu;
 
 	if (material.plasticity == true) {
-		double *eps_p_new = NULL, * alpha_new = NULL;
+		double *eps_p_new = NULL, *alpha_new = NULL;
 		double * const eps_p_old = &vars_old[intvar_ix(e, gp, 0)];
 		const double alpha_old = vars_old[intvar_ix(e, gp, 6)];
 
@@ -317,7 +316,7 @@ void micropp<3>::get_strain(int gp, double *strain_gp,
 template <>
 template <>
 void micropp<3>::get_elem_rhs(bool *non_linear,
-                             double *be, int ex, int ey, int ez) const
+                              double *be, int ex, int ey, int ez) const
 {
 	double bmat[6][3 * 8], cxb[6][3 * 8], stress_gp[6];
 	const double wg = (1 / 8.0) * dx * dy * dz;
@@ -355,26 +354,27 @@ double micropp<3>::assembly_rhs(bool *non_linear)
 	double be[3 * 8];
 	int index[3 * 8];
 
+	const int nxny = nx * ny;
+
 	for (int ex = 0; ex < nx - 1; ex++) {
 		for (int ey = 0; ey < ny - 1; ey++) {
 			for (int ez = 0; ez < nz - 1; ez++) {
 
-				const int n[npe] = { ez * (nx * ny) + ey * nx + ex,
-				                     ez * (nx * ny) + ey * nx + ex + 1,
-				                     ez * (nx * ny) + (ey + 1) * nx + ex + 1,
-				                     ez * (nx * ny) + (ey + 1) * nx + ex,
-				                     n[0] + nx * ny,
-				                     n[1] + nx * ny,
-				                     n[2] + nx * ny,
-				                     n[3] + nx * ny };
+				const int n[npe] = { ez * nxny + ey * nx + ex,
+				                     ez * nxny + ey * nx + ex + 1,
+				                     ez * nxny + (ey + 1) * nx + ex + 1,
+				                     ez * nxny + (ey + 1) * nx + ex,
+				                     n[0] + nxny,
+				                     n[1] + nxny,
+				                     n[2] + nxny,
+				                     n[3] + nxny };
 
-				for (int j = 0; j < npe; ++j) {
-					for (int d = 0; d < dim; ++d) {
+				for (int j = 0; j < npe; ++j)
+					for (int d = 0; d < dim; ++d)
 						index[j * dim + d] = n[j] * dim + d;
-					}
-				}
 
 				get_elem_rhs(&non_linear_one_elem, be, ex, ey, ez);
+
 				if (non_linear_one_elem)
 					*non_linear = true;
 
@@ -386,50 +386,50 @@ double micropp<3>::assembly_rhs(bool *non_linear)
 
 	// boundary conditions
 	// z=0
-	for (int i = 0; i < nx; i++) {
-		for (int j = 0; j < ny; j++) {
+	for (int i = 0; i < nx; ++i) {
+		for (int j = 0; j < ny; ++j) {
 			const int n = nod_index(i, j, 0);
-			for (int d = 0; d < dim; d++)
+			for (int d = 0; d < dim; ++d)
 				b[n * dim + d] = 0.0;
 		}
 	}
 	// z = lx
-	for (int i = 0; i < nx; i++) {
-		for (int j = 0; j < ny; j++) {
+	for (int i = 0; i < nx; ++i) {
+		for (int j = 0; j < ny; ++j) {
 			const int n = nod_index(i, j, nz - 1);
-			for (int d = 0; d < dim; d++)
+			for (int d = 0; d < dim; ++d)
 				b[n * dim + d] = 0.0;
 		}
 	}
 	// y = 0
-	for (int i = 0; i < nx; i++) {
-		for (int k = 1; k < nz - 1; k++) {
+	for (int i = 0; i < nx; ++i) {
+		for (int k = 1; k < nz - 1; ++k) {
 			const int n = nod_index(i, 0, k);
-			for (int d = 0; d < dim; d++)
+			for (int d = 0; d < dim; ++d)
 				b[n * dim + d] = 0.0;
 		}
 	}
 	// y = ly
-	for (int i = 0; i < nx; i++) {
-		for (int k = 1; k < nz - 1; k++) {
+	for (int i = 0; i < nx; ++i) {
+		for (int k = 1; k < nz - 1; ++k) {
 			const int n = nod_index(i, ny - 1, k);
 			for (int d = 0; d < dim; d++)
 				b[n * dim + d] = 0.0;
 		}
 	}
 	// x=0
-	for (int j = 1; j < ny - 1; j++) {
-		for (int k = 1; k < nz - 1; k++) {
+	for (int j = 1; j < ny - 1; ++j) {
+		for (int k = 1; k < nz - 1; ++k) {
 			const int n = nod_index(0, j, k);
-			for (int d = 0; d < dim; d++)
+			for (int d = 0; d < dim; ++d)
 				b[n * dim + d] = 0.0;
 		}
 	}
 	// x=lx
 	for (int j = 1; j < ny - 1; j++) {
-		for (int k = 1; k < nz - 1; k++) {
+		for (int k = 1; k < nz - 1; ++k) {
 			const int n = nod_index(nx - 1, j, k);
-			for (int d = 0; d < dim; d++)
+			for (int d = 0; d < dim; ++d)
 				b[n * dim + d] = 0.0;
 		}
 	}
@@ -449,7 +449,7 @@ double micropp<3>::assembly_rhs(bool *non_linear)
 
 template <>
 template <>
-void micropp<3>::get_elem_mat(double Ae[3 * 8 * 3 * 8], int ex, int ey, int ez)
+void micropp<3>::get_elem_mat(double Ae[3 * 8 * 3 * 8], int ex, int ey, int ez) const
 {
 	INST_START;
 	const int e = glo_elem3D(ex, ey, ez);
@@ -463,7 +463,7 @@ void micropp<3>::get_elem_mat(double Ae[3 * 8 * 3 * 8], int ex, int ey, int ez)
 	  last 3 components are without the 2 because we use eps = {e11 e22 e33 2*e12 2*e13 2*e23}
 	*/
 
-	for (int i = 0; i < npedim * npedim; i++)
+	for (int i = 0; i < npedim * npedim; ++i)
 		Ae[i] = 0.0;
 
 	for (int gp = 0; gp < npe; ++gp) {
@@ -520,9 +520,9 @@ void micropp<3>::assembly_mat()
 	ell_set_zero_mat(&A);
 
 	double Ae[3 * 8 * 3 * 8];
-	for (int ex = 0; ex < nx - 1; ex++) {
-		for (int ey = 0; ey < ny - 1; ey++) {
-			for (int ez = 0; ez < nz - 1; ez++) {
+	for (int ex = 0; ex < nx - 1; ++ex) {
+		for (int ey = 0; ey < ny - 1; ++ey) {
+			for (int ez = 0; ez < nz - 1; ++ez) {
 				get_elem_mat(Ae, ex, ey, ez);
 				ell_add_struct3D(&A, ex, ey, ez, Ae, dim, nx, ny, nz);
 			}
@@ -533,28 +533,28 @@ void micropp<3>::assembly_mat()
 
 
 template <>
-void micropp<3>::calc_ave_stress(double stress_ave[6])
+void micropp<3>::calc_ave_stress(double stress_ave[6]) const
 {
 	bool non_linear_flag;
 	const double wg = (1 / 8.0) * dx * dy * dz;
 
-	for (int v = 0; v < nvoi; v++)
+	for (int v = 0; v < nvoi; ++v)
 		stress_ave[v] = 0.0;
 
-	for (int ex = 0; ex < nx - 1; ex++) {
-		for (int ey = 0; ey < ny - 1; ey++) {
-			for (int ez = 0; ez < nz - 1; ez++) {
+	for (int ex = 0; ex < nex; ++ex) {
+		for (int ey = 0; ey < ney; ++ey) {
+			for (int ez = 0; ez < nez; ++ez) {
 
 				double stress_aux[6] = { 0.0 };
 
 				for (int gp = 0; gp < npe; ++gp) {
 
 					double stress_gp[6];
-
 					double strain_gp[6];
+
 					get_strain(gp, strain_gp, ex, ey, ez);
-					get_stress(gp, strain_gp, &non_linear_flag, stress_gp,
-					           ex, ey, ez);
+					get_stress(gp, strain_gp, &non_linear_flag,
+					           stress_gp, ex, ey, ez);
 					for (int v = 0; v < nvoi; ++v)
 						stress_aux[v] += stress_gp[v] * wg;
 
@@ -571,24 +571,24 @@ void micropp<3>::calc_ave_stress(double stress_ave[6])
 
 
 template <>
-void micropp<3>::calc_ave_strain(double strain_ave[6])
+void micropp<3>::calc_ave_strain(double strain_ave[6]) const
 {
 	const double wg = (1 / 8.0) * dx * dy * dz;
 
-	for (int v = 0; v < nvoi; v++)
+	for (int v = 0; v < nvoi; ++v)
 		strain_ave[v] = 0.0;
 
-	for (int ex = 0; ex < nx - 1; ex++) {
-		for (int ey = 0; ey < ny - 1; ey++) {
-			for (int ez = 0; ez < nz - 1; ez++) {
+	for (int ex = 0; ex < nex; ++ex) {
+		for (int ey = 0; ey < ney; ++ey) {
+			for (int ez = 0; ez < nez; ++ez) {
 
 				double strain_aux[6] = { 0.0 };
 
-				for (int gp = 0; gp < npe; gp++) {
+				for (int gp = 0; gp < npe; ++gp) {
 					double strain_gp[6];
 
 					get_strain(gp, strain_gp, ex, ey, ez);
-					for (int v = 0; v < nvoi; v++)
+					for (int v = 0; v < nvoi; ++v)
 						strain_aux[v] += strain_gp[v] * wg;
 				}
 
@@ -597,7 +597,6 @@ void micropp<3>::calc_ave_strain(double strain_ave[6])
 			}
 		}
 	}
-
 
 	for (int v = 0; v < nvoi; v++)
 		strain_ave[v] /= (lx * ly);
@@ -612,14 +611,14 @@ void micropp<3>::calc_fields()
 	const double ivol = 1.0 / (dx * dy * dz);
 	const double wg = (1 / 8.0) * dx * dy * dz;
 
-	for (int ex = 0; ex < nx - 1; ex++) {
-		for (int ey = 0; ey < ny - 1; ey++) {
-			for (int ez = 0; ez < nz - 1; ez++) {
+	for (int ex = 0; ex < nex; ++ex) {
+		for (int ey = 0; ey < ney; ++ey) {
+			for (int ez = 0; ez < nez; ++ez) {
 
 				double strain_aux[6] = { 0.0 };
 				double stress_aux[6] = { 0.0 };
 
-				for (int gp = 0; gp < npe; gp++) {
+				for (int gp = 0; gp < npe; ++gp) {
 
 					double stress_gp[6], strain_gp[6];
 
@@ -629,7 +628,6 @@ void micropp<3>::calc_fields()
 						strain_aux[v] += strain_gp[v] * wg;
 						stress_aux[v] += stress_gp[v] * wg;
 					}
-
 				}
 
 				const int e = glo_elem3D(ex, ey, ez);

--- a/src/micro3D_exclusive.cpp
+++ b/src/micro3D_exclusive.cpp
@@ -30,7 +30,8 @@
 using namespace std;
 
 template <>
-void micropp<3>::get_ctan_plast_sec(int ex, int ey, int ez, int gp, double ctan[6][6])
+void micropp<3>::get_ctan_plast_sec(int ex, int ey, int ez,
+                                    int gp, double ctan[6][6]) const
 {
 	INST_START;
 	bool non_linear;
@@ -56,7 +57,8 @@ void micropp<3>::get_ctan_plast_sec(int ex, int ey, int ez, int gp, double ctan[
 
 
 template <>
-void micropp<3>::get_ctan_plast_exact(int ex, int ey, int ez, int gp, double ctan[6][6])
+void micropp<3>::get_ctan_plast_exact(int ex, int ey, int ez,
+                                      int gp, double ctan[6][6]) const
 {
 	INST_START;
 	double strain[6];
@@ -82,7 +84,8 @@ void micropp<3>::get_ctan_plast_exact(int ex, int ey, int ez, int gp, double cta
 }
 
 template <>
-void micropp<3>::get_ctan_plast_pert(int ex, int ey, int ez, int gp, double ctan[6][6])
+void micropp<3>::get_ctan_plast_pert(int ex, int ey, int ez,
+                                     int gp, double ctan[6][6]) const
 {
 	INST_START;
 	bool non_linear;

--- a/src/micro_common.cpp
+++ b/src/micro_common.cpp
@@ -221,6 +221,15 @@ material_t micropp<tdim>::get_material(const int e) const
 	return material_list[mat_num];
 }
 
+
+template <int tdim>
+void micropp<tdim>::print_info() const
+{
+	printf("micropp%d\n", dim);
+	printf("ngp %d n = [%d, %d, %d] => nn = %d\n", ngp, nx, ny, nz, nn);
+	printf("l = [%lf, %lf, %lf]; width = %lf\n", lx, ly, lz, width);
+}
+
 // Explicit instantiation
 template class micropp<2>;
 template class micropp<3>;

--- a/src/solve.cpp
+++ b/src/solve.cpp
@@ -32,14 +32,17 @@ void micropp<tdim>::newton_raphson(bool *nl_flag, int *its, double *err)
 	double lerr = 0.0;
 
 	do {
-		lerr = assembly_rhs(nl_flag);
+		lerr = assembly_rhs(nl_flag);  // Acts on b
 
 		if (lerr < NR_MAX_TOL)
 			break;
 
-		assembly_mat();
+		assembly_mat();   // Acts on A
 
+		// Move this inside ell_solve_cgpd_struct
 		memset(du, 0.0, nn * dim * sizeof(double));
+
+		// in(b) inout
 		ell_solve_cgpd_struct(&solver, &A, dim, dim, nn, b, du);
 
 		for (int i = 0; i < nn * dim; ++i)
@@ -47,7 +50,7 @@ void micropp<tdim>::newton_raphson(bool *nl_flag, int *its, double *err)
 
 		lits++;
 
-	} while ((lits < NR_MAX_ITS) && (lerr > NR_MAX_TOL));
+	} while (lits < NR_MAX_ITS);
 
 	*its = lits;
 	*err = lerr;

--- a/src/wrapper.cpp
+++ b/src/wrapper.cpp
@@ -1,0 +1,87 @@
+/*
+ *  This source code is part of MicroPP: a finite element library
+ *  to solve microstructural problems for composite materials.
+ *
+ *  Copyright (C) - 2018 - Jimmy Aguilar Mena <kratsbinovish@gmail.com>
+ *                         Guido Giuntoli <gagiuntoli@gmail.com>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "micro.hpp"
+
+extern "C" {
+
+	micropp<3> *init3_(int *ngp, const int size[3], const int *micro_type,
+	                   const double *micro_params, const int *mat_types,
+	                   const double *params)
+	{
+		return new micropp<3>(*ngp, size, *micro_type, micro_params,
+		                      mat_types, params);
+	}
+
+	void free3_(micropp<3> **in)
+	{
+		delete (*in);
+	}
+
+	int get_nl_flag3_(const micropp<3> **self,int *gp_id)
+	{
+		return (*self)->get_nl_flag(*gp_id);
+	}
+
+	void set_macro_strain3_(micropp<3> **self, const int *gp_id,
+	                        const double *macro_strain)
+	{
+		(*self)->set_macro_strain(*gp_id, macro_strain);
+	}
+
+	void get_macro_stress3_(const micropp<3> **self,
+	                        const int *gp_id, double *macro_stress)
+	{
+		(*self)->get_macro_stress(*gp_id, macro_stress);
+	}
+
+	void get_macro_ctan3_(const micropp<3> **self, const int *gp_id,
+	                     double *macro_ctan)
+	{
+		(*self)->get_macro_ctan(*gp_id, macro_ctan);
+	}
+
+	void homogenize3_(micropp<3> **self)
+	{
+		(*self)->homogenize();
+	}
+
+	void update_vars3_(micropp<3> **self)
+	{
+		(*self)->update_vars();
+	}
+
+	void output3_(micropp<3> **self, int *tstep, int *gp_id)
+	{
+		(*self)->output(*tstep, *gp_id);
+	}
+
+	void write_info_files3_(micropp<3> **self)
+	{
+		(*self)->write_info_files();
+	}
+
+	void print_info3_(micropp<3> **self)
+	{
+		printf("ptr2 %p\n", self);
+		(*self)->print_info();
+	}
+}

--- a/src/wrapper.f95
+++ b/src/wrapper.f95
@@ -1,0 +1,97 @@
+!
+! This file is part of the Fortran_C++ program.
+! Copyright (c) 2018 Jimmy Aguilar Mena.
+!
+! This program is free software: you can redistribute it and/or modify
+! it under the terms of the GNU General Public License as published by
+! the Free Software Foundation, version 3.
+!
+! This program is distributed in the hope that it will be useful, but
+! WITHOUT ANY WARRANTY; without even the implied warranty of
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+! General Public License for more details.
+!
+! You should have received a copy of the GNU General Public License
+! along with this program. If not, see <http://www.gnu.org/licenses/>.
+!
+
+module libmicropp
+  implicit none
+
+  private :: new_micropp3, set_macro_strain, homogenize, &
+       get_macro_stress, update_vars, write_info_files
+
+  public :: micropp3, free
+
+  type :: micropp3
+     private
+     integer(8) :: ptr ! pointer
+   contains
+     procedure :: print_info, set_macro_strain, homogenize,&
+          get_macro_stress, update_vars, write_info_files
+  end type micropp3
+
+  interface micropp3
+     procedure new_micropp3
+  end interface micropp3
+
+  integer(8) :: init3
+  external init3
+
+contains
+  function new_micropp3(ngp, size, micro_type, micro_params,&
+       mat_types, params)
+    implicit none
+    type(micropp3) :: new_micropp3
+    integer, intent(in) :: ngp
+    integer, intent(in) :: size(3)
+    integer, intent(in) :: micro_type
+    real(8), intent(in), dimension (*) :: micro_params
+    integer, intent(in), dimension (*) :: mat_types
+    real(8), intent(in), dimension (*) :: params
+
+    new_micropp3%ptr = init3(ngp, size, micro_type, micro_params, &
+         mat_types, params)
+
+  end function new_micropp3
+
+  subroutine free(this)
+    class(micropp3) :: this
+    call free3(this%ptr)
+  end subroutine free
+
+  subroutine set_macro_strain(this, gp_id, macro_strain)
+    class(micropp3), intent(inout) :: this
+    integer, intent(in) :: gp_id
+    real(8), intent(in), dimension(*) :: macro_strain
+    call set_macro_strain3(this%ptr, gp_id, macro_strain)
+  end subroutine set_macro_strain
+
+  subroutine homogenize(this)
+    class(micropp3) :: this
+    call homogenize3(this%ptr)
+  end subroutine homogenize
+
+  subroutine get_macro_stress(this, gp_id, macro_stress)
+    class(micropp3) :: this
+    integer, intent(in) :: gp_id
+    real(8), intent(in), dimension(*) :: macro_stress
+    call get_macro_stress3(this%ptr, gp_id, macro_stress)
+  end subroutine get_macro_stress
+
+  subroutine update_vars(this)
+    class(micropp3) :: this
+    call update_vars3(this%ptr)
+  end subroutine update_vars
+
+  subroutine write_info_files(this)
+    class(micropp3) :: this
+    call write_info_files3(this%ptr)
+  end subroutine write_info_files
+
+  subroutine print_info(this)
+    class(micropp3) :: this
+    call print_info3(this%ptr)
+  end subroutine print_info
+
+end module libmicropp

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -6,7 +6,7 @@ set(testsources
   test2d_1.cpp
   test3d_1.cpp
   test3d_2.cpp
-  #test3d_3.f90
+  test3d_3.f90
   test3d_4.cpp
   test3d_5.cpp)
 
@@ -23,12 +23,10 @@ endforeach ()
 # As some tests will require commands and could be executed in loops we add the
 # tests individually here.
 
-# Add tests with no arguments.
-# add_test(test3d_3 test3d_3)
-
 # Add a test that requires arguments
 add_test(NAME test2d_1 COMMAND test2d_1 5 5 10)
 add_test(NAME test3d_1 COMMAND test3d_1 5 5 5 1)
-#add_test(NAME test3d_2 COMMAND test3d_3 5 5 5 10)
+add_test(NAME test3d_2 COMMAND test3d_2 5 5 5 10)
+add_test(NAME test3d_3 COMMAND test3d_3 5 5 5 10)
 add_test(NAME test3d_4 COMMAND test3d_4 5 5 5 5 10)
 add_test(NAME test3d_5 COMMAND test3d_5 5 5 5)

--- a/test/test3d_2.cpp
+++ b/test/test3d_2.cpp
@@ -42,51 +42,48 @@ int main (int argc, char *argv[])
 	const int nz = atoi(argv[3]);
 	const int time_steps = (argc > 4 ? atoi(argv[4]) : 10);  // Optional value
 
-	int size[3];
-	size[0] = nx;
-	size[1] = ny;
-	size[2] = nz;
+	int size[3] = { nx, ny, nz };
 
-	int micro_type = 1; // 2 materiales matriz y fibra (3D esfera en matriz)
+	// 2 materiales matriz y fibra (3D esfera en matriz)
+	const int micro_type = 1;
+
 	double micro_params[5];
 	micro_params[0] = 1.0; // lx
 	micro_params[1] = 1.0; // ly
 	micro_params[2] = 1.0; // lz
 	micro_params[3] = 0.1; // grosor capa de abajo
-	micro_params[4] = 0; // INV_MAX
+	micro_params[4] = 0.0; // INV_MAX
 
-	int mat_types[2]; // dos materiales lineales (type = 0)
-	mat_types[0] = 1;
-	mat_types[1] = 0;
+	int mat_types[2] = { 1, 0 }; // dos materiales lineales (type = 0)
 
-	double mat_params[2*MAX_MAT_PARAM];
-	mat_params[0*MAX_MAT_PARAM + 0] = 1.0e6; // E
-	mat_params[0*MAX_MAT_PARAM + 1] = 0.3;   // nu
-	mat_params[0*MAX_MAT_PARAM + 2] = 5.0e4; // Sy
-	mat_params[0*MAX_MAT_PARAM + 3] = 5.0e4; // Ka
+	double mat_params[2 * MAX_MAT_PARAM];
+	mat_params[0 * MAX_MAT_PARAM + 0] = 1.0e6; // E
+	mat_params[0 * MAX_MAT_PARAM + 1] = 0.3;   // nu
+	mat_params[0 * MAX_MAT_PARAM + 2] = 5.0e4; // Sy
+	mat_params[0 * MAX_MAT_PARAM + 3] = 5.0e4; // Ka
 
-	mat_params[1*MAX_MAT_PARAM + 0] = 1.0e6;
-	mat_params[1*MAX_MAT_PARAM + 1] = 0.3;
-	mat_params[1*MAX_MAT_PARAM + 2] = 1.0e4;
-	mat_params[1*MAX_MAT_PARAM + 3] = 0.0e-1;
+	mat_params[1 * MAX_MAT_PARAM + 0] = 1.0e6;
+	mat_params[1 * MAX_MAT_PARAM + 1] = 0.3;
+	mat_params[1 * MAX_MAT_PARAM + 2] = 1.0e4;
+	mat_params[1 * MAX_MAT_PARAM + 3] = 0.0e-1;
 
 	micropp<3> micro(1, size, micro_type, micro_params, mat_types, mat_params);
 
-	double sig[6], ctan[36];
-	double d_eps = 0.01;
+	double sig[6];
+	const double d_eps = 0.01;
 	int dir = 2;
 
 	double eps[6] = {0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
-	for (int t = 0; t < time_steps; ++t)
-	{
+
+	for (int t = 0; t < time_steps; ++t) {
 		cout << "time step = " << t << endl;
-		if (t<30)
+		if (t < 30)
 			eps[dir] += d_eps;
-		else if (t<80)
+		else if (t < 80)
 			eps[dir] -= d_eps;
-		else if (t<130)
+		else if (t < 130)
 			eps[dir] += d_eps;
-		else if (t<250)
+		else if (t < 250)
 			eps[dir] -= d_eps;
 		else
 			eps[dir] += d_eps;
@@ -97,7 +94,7 @@ int main (int argc, char *argv[])
 		micro.get_macro_stress(0, sig);
 
 		micro.update_vars();
-		micro.write_info_files ();
+		micro.write_info_files();
 
 		cout << "eps = " << eps[dir] << endl;
 		cout

--- a/test/test3d_5.cpp
+++ b/test/test3d_5.cpp
@@ -78,7 +78,7 @@ int main(int argc, char **argv)
 	double sig[6], (*sig_test)[3];
 
     sig_test = (double (*)[3]) malloc (3 * ngp * sizeof(double));
-	
+
     micropp<dim> micro(ngp, size, micro_type, micro_params, mat_types, mat_params);
 
 	for (int t = 0; t < time_steps; ++t) {
@@ -119,7 +119,7 @@ int main(int argc, char **argv)
 				cout << setw(14) << sig[i] << " ";
 			cout << endl;
 
-            memcpy(sig_test[gp], sig, 3*sizeof(double));
+            memcpy(sig_test[gp], sig, 3 * sizeof(double));
 		}
 
 		for (int gp = 2; gp < ngp; ++gp) {


### PR DESCRIPTION
- Added a Fortran wrapper for the 3D version of microcpp and a test for it.
- The wrapper is useful also for C if desired.
- With this wrapper is enough to create also a python interface.
- The test 3d_3 was modified to be equal to 3d_2, and have a matching pattern to compare.