### PR TITLE
Improve performances

### DIFF
--- a/src/assembly_acc.cpp
+++ b/src/assembly_acc.cpp
@@ -73,7 +73,7 @@ void micropp<3>::get_elem_mat_acc(const double *u,
 				double tmp = 0.0;
 				for (int k = 0; k < nvoi; ++k)
 					tmp += ctan[i][k] * bmat[k][j];
-				cxb[i][j] = tmp;
+				cxb[i][j] = tmp * wg;
 			}
 		}
 
@@ -82,7 +82,7 @@ void micropp<3>::get_elem_mat_acc(const double *u,
 				const int inpedim = i * npedim;
 				const double bmatmi = bmat[m][i];
 				for (int j = 0; j < npedim; ++j)
-					TAe[inpedim + j] += bmatmi * cxb[m][j] * wg;
+					TAe[inpedim + j] += bmatmi * cxb[m][j];
 			}
 		}
 	}

--- a/src/micro_common.cpp
+++ b/src/micro_common.cpp
@@ -271,7 +271,7 @@ void micropp<tdim>::get_elem_mat(const double *u,
 				double tmp = 0.0;
 				for (int k = 0; k < nvoi; ++k)
 					tmp += ctan[i][k] * bmat[k][j];
-				cxb[i][j] = tmp;
+				cxb[i][j] = tmp * wg;
 			}
 		}
 
@@ -280,7 +280,7 @@ void micropp<tdim>::get_elem_mat(const double *u,
 				const int inpedim = i * npedim;
 				const double bmatmi = bmat[m][i];
 				for (int j = 0; j < npedim; ++j)
-					TAe[inpedim + j] += bmatmi * cxb[m][j] * wg;
+					TAe[inpedim + j] += bmatmi * cxb[m][j];
 			}
 		}
 	}


### PR DESCRIPTION
From test on Paragon (Power8 CPU, K100 GPU), on test3d_1 100 1 1

Without OpenACC
Before commit: 15m35s
After commit : 13m53s
Speedup of 1.12

With OpenACC:
Before commit: 6m31s
After commit : 4m47s
Speedup of 1.36